### PR TITLE
fix(samples): do not pass location

### DIFF
--- a/samples/batch_parse_form.js
+++ b/samples/batch_parse_form.js
@@ -19,7 +19,6 @@ const uuid = require('uuid');
 
 async function main(
   projectId = 'YOUR_PROJECT_ID',
-  location = 'YOUR_PROJECT_LOCATION',
   gcsOutputUri = 'output-bucket',
   gcsOutputUriPrefix = uuid.v4(),
   gcsInputUri = 'gs://cloud-samples-data/documentai/invoice.pdf'
@@ -29,7 +28,6 @@ async function main(
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // const projectId = 'YOUR_PROJECT_ID';
-  // const location = 'YOUR_PROJECT_LOCATION',
   // const gcsOutputUri = 'YOUR_STORAGE_BUCKET';
   // const gcsOutputUriPrefix = 'YOUR_STORAGE_PREFIX';
   // const gcsInputUri = 'GCS URI of the PDF to process';
@@ -44,7 +42,7 @@ async function main(
   const storage = new Storage();
 
   async function parseFormGCS(inputUri, outputUri, outputUriPrefix) {
-    const parent = `projects/${projectId}/locations/${location}`;
+    const parent = `projects/${projectId}`;
 
     // Configure the batch process request.
     const request = {

--- a/samples/batch_parse_table.js
+++ b/samples/batch_parse_table.js
@@ -19,7 +19,6 @@ const uuid = require('uuid');
 
 async function main(
   projectId = 'YOUR_PROJECT_ID',
-  location = 'YOUR_PROJECT_LOCATION',
   gcsOutputUri = 'output-bucket',
   gcsOutputUriPrefix = uuid.v4(),
   gcsInputUri = 'gs://cloud-samples-data/documentai/invoice.pdf'
@@ -29,7 +28,6 @@ async function main(
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // const projectId = 'YOUR_PROJECT_ID';
-  // const location = 'YOUR_PROJECT_LOCATION';
   // const gcsOutputUri = 'YOUR_STORAGE_BUCKET';
   // const gcsOutputUriPrefix = 'YOUR_STORAGE_PREFIX';
   // const gcsInputUri = 'YOUR_SOURCE_PDF';
@@ -44,7 +42,7 @@ async function main(
   const storage = new Storage();
 
   async function parseTableGCS(inputUri, outputUri, outputUriPrefix) {
-    const parent = `projects/${projectId}/locations/${location}`;
+    const parent = `projects/${projectId}`;
 
     // Configure the batch process request.
     const request = {

--- a/samples/parse_form.js
+++ b/samples/parse_form.js
@@ -18,12 +18,10 @@
 /**
  * Process a single PDF as a form.
  * @param {string} projectId your Google Cloud project ID
- * @param {string} location region to use for this operation
  * @param {string} gcsInputUri Cloud Storage URI of the PDF document to parse
  */
 async function main(
   projectId,
-  location,
   gcsInputUri = 'gs://cloud-samples-data/documentai/invoice.pdf'
 ) {
   // [START documentai_parse_form]
@@ -31,7 +29,6 @@ async function main(
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // const projectId = 'YOUR_PROJECT_ID';
-  // const location = 'YOUR_PROJECT_LOCATION';
   // const gcsInputUri = 'YOUR_SOURCE_PDF';
 
   const {
@@ -41,7 +38,7 @@ async function main(
 
   async function parseForm() {
     // Configure the request for processing the PDF
-    const parent = `projects/${projectId}/locations/${location}`;
+    const parent = `projects/${projectId}`;
     const request = {
       parent,
       inputConfig: {

--- a/samples/parse_table.js
+++ b/samples/parse_table.js
@@ -18,12 +18,10 @@
 /**
  * Process a single PDF.
  * @param {string} projectId your Google Cloud project ID
- * @param {string} location region to use for this operation
  * @param {string} gcsInputUri Cloud Storage URI of the PDF document to parse
  */
 async function main(
   projectId,
-  location,
   gcsInputUri = 'gs://cloud-samples-data/documentai/invoice.pdf'
 ) {
   // [START documentai_parse_table]
@@ -31,7 +29,6 @@ async function main(
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // const projectId = 'YOUR_PROJECT_ID';
-  // const location = 'YOUR_PROJECT_LOCATION';
   // const gcsInputUri = 'YOUR_SOURCE_PDF';
 
   const {
@@ -41,7 +38,7 @@ async function main(
 
   async function parseTable() {
     // Configure the request for processing the PDF
-    const parent = `projects/${projectId}/locations/${location}`;
+    const parent = `projects/${projectId}`;
     const request = {
       parent,
       inputConfig: {

--- a/samples/parse_with_model.js
+++ b/samples/parse_with_model.js
@@ -18,13 +18,11 @@
 /**
  * Process a single PDF.
  * @param {string} projectId your Google Cloud project ID
- * @param {string} location region to use for this operation
  * @param {string} autoMLModel AutoML Natural Language model to use
  * @param {string} gcsInputUri Cloud Storage URI of the PDF document to parse
  */
 async function main(
   projectId,
-  location,
   autoMLModel,
   gcsInputUri = 'gs://cloud-samples-data/documentai/invoice.pdf'
 ) {
@@ -33,7 +31,6 @@ async function main(
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // const projectId = 'YOUR_PROJECT_ID';
-  // const location = 'YOUR_PROJECT_LOCATION';
   // const autoMLModel = 'Full resource name of AutoML Natural Language model';
   // const gcsInputUri = 'YOUR_SOURCE_PDF';
 
@@ -44,7 +41,7 @@ async function main(
 
   async function parseWithModel() {
     // Configure the request for processing the PDF
-    const parent = `projects/${projectId}/locations/${location}`;
+    const parent = `projects/${projectId}`;
     const request = {
       parent,
       inputConfig: {

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -18,12 +18,10 @@
 /**
  * Process a single PDF.
  * @param {string} projectId your Google Cloud project ID
- * @param {string} location region to use for this operation
  * @param {string} gcsInputUri Cloud Storage URI of the PDF document to parse
  */
 async function main(
   projectId,
-  location,
   gcsInputUri = 'gs://cloud-samples-data/documentai/invoice.pdf'
 ) {
   // [START documentai_quickstart]
@@ -31,7 +29,6 @@ async function main(
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // const projectId = 'YOUR_PROJECT_ID';
-  // const location = 'YOUR_PROJECT_LOCATION';
   // const gcsInputUri = 'YOUR_SOURCE_PDF';
 
   const {
@@ -41,7 +38,7 @@ async function main(
 
   async function quickstart() {
     // Configure the request for processing the PDF
-    const parent = `projects/${projectId}/locations/${location}`;
+    const parent = `projects/${projectId}`;
     const request = {
       parent,
       inputConfig: {

--- a/samples/set_endpoint.js
+++ b/samples/set_endpoint.js
@@ -18,12 +18,10 @@
 /**
  * Process a single PDF.
  * @param {string} projectId your Google Cloud project ID
- * @param {string} location region to use for this operation
  * @param {string} gcsInputUri Cloud Storage URI of the PDF document to parse
  */
 async function main(
   projectId,
-  location = 'europe-west2',
   gcsInputUri = 'gs://cloud-samples-data/documentai/invoice.pdf'
 ) {
   // [START documentai_set_endpoint]
@@ -31,7 +29,6 @@ async function main(
    * TODO(developer): Uncomment these variables before running the sample.
    */
   // const projectId = 'YOUR_PROJECT_ID';
-  // const location = 'Location for operation--must match region of endpoint';
   // const gcsInputUri = 'YOUR_SOURCE_PDF';
 
   const {
@@ -44,7 +41,7 @@ async function main(
 
   async function setEndpoint() {
     // Configure the request for processing the PDF
-    const parent = `projects/${projectId}/locations/${location}`;
+    const parent = `projects/${projectId}`;
     const request = {
       parent,
       inputConfig: {

--- a/samples/test/batch_parse_form.test.js
+++ b/samples/test/batch_parse_form.test.js
@@ -28,7 +28,6 @@ const cmd = 'node batch_parse_form.js';
 
 const testParseForm = {
   projectId: process.env.GCLOUD_PROJECT,
-  location: 'us-central1',
   gcsOutputUriPrefix: uuid.v4(),
 };
 
@@ -45,7 +44,7 @@ describe('Document AI batch parse form', () => {
 
   it('should parse the GCS invoice example as a form', async () => {
     const output = execSync(
-      `${cmd} ${testParseForm.projectId} ${testParseForm.location} gs://${bucketName}`
+      `${cmd} ${testParseForm.projectId} gs://${bucketName}`
     );
     assert.match(output, /Extracted key value pair:/);
   });

--- a/samples/test/batch_parse_table.test.js
+++ b/samples/test/batch_parse_table.test.js
@@ -28,7 +28,6 @@ const cmd = 'node batch_parse_table.js';
 
 const testParseTable = {
   projectId: process.env.GCLOUD_PROJECT,
-  location: 'us-central1',
   gcsOutputUriPrefix: uuid.v4(),
 };
 
@@ -45,7 +44,7 @@ describe('Document AI batch parse table', () => {
 
   it('should parse the GCS invoice example as as table', async () => {
     const output = execSync(
-      `${cmd} ${testParseTable.projectId} ${testParseTable.location} gs://${bucketName}`
+      `${cmd} ${testParseTable.projectId} gs://${bucketName}`
     );
     assert.match(output, /First detected language:/);
   });

--- a/samples/test/parse_form.test.js
+++ b/samples/test/parse_form.test.js
@@ -23,11 +23,10 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cwd = path.join(__dirname, '..');
 const projectId = process.env.GCLOUD_PROJECT;
-const LOCATION = 'us-central1';
 
 describe('Document AI parse form', () => {
   it('should parse the GCS invoice example as a form', async () => {
-    const stdout = execSync(`node ./parse_form.js ${projectId} ${LOCATION}`, {
+    const stdout = execSync(`node ./parse_form.js ${projectId}`, {
       cwd,
     });
     assert.match(stdout, /Extracted key value pair:/);

--- a/samples/test/parse_table.test.js
+++ b/samples/test/parse_table.test.js
@@ -23,11 +23,10 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cwd = path.join(__dirname, '..');
 const projectId = process.env.GCLOUD_PROJECT;
-const LOCATION = 'us-central1';
 
 describe('Document AI parse table', () => {
   it('should parse the GCS invoice example as as table', async () => {
-    const stdout = execSync(`node ./parse_table.js ${projectId} ${LOCATION}`, {
+    const stdout = execSync(`node ./parse_table.js ${projectId}`, {
       cwd,
     });
     assert.match(stdout, /Header row/);

--- a/samples/test/parse_with_model.test.js
+++ b/samples/test/parse_with_model.test.js
@@ -23,7 +23,6 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cwd = path.join(__dirname, '..');
 const projectId = process.env.GCLOUD_PROJECT;
-const LOCATION = 'us-central1';
 const MODEL_NAME =
   process.env.MODEL_NAME ||
   'projects/1046198160504/locations/us-central1/models/TCN7483069430457434112';
@@ -31,7 +30,7 @@ const MODEL_NAME =
 describe('Document AI parse with AutoML model', () => {
   it('should run use an AutoML model to parse a PDF', async () => {
     const stdout = execSync(
-      `node ./parse_with_model.js ${projectId} ${LOCATION} ${MODEL_NAME}`,
+      `node ./parse_with_model.js ${projectId} ${MODEL_NAME}`,
       {
         cwd,
       }

--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -23,11 +23,10 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cwd = path.join(__dirname, '..');
 const projectId = process.env.GCLOUD_PROJECT;
-const LOCATION = 'us-central1';
 
 describe('Quickstart', () => {
   it('should run quickstart', async () => {
-    const stdout = execSync(`node ./quickstart.js ${projectId} ${LOCATION}`, {
+    const stdout = execSync(`node ./quickstart.js ${projectId}`, {
       cwd,
     });
     assert.match(stdout, /Entity/);

--- a/samples/test/set_endpoint.test.js
+++ b/samples/test/set_endpoint.test.js
@@ -23,11 +23,10 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const cwd = path.join(__dirname, '..');
 const projectId = process.env.GCLOUD_PROJECT;
-const LOCATION = 'europe-west2';
 
 describe('Document AI set endpoint', () => {
   it('should process a PDF in another region', async () => {
-    const stdout = execSync(`node ./set_endpoint.js ${projectId} ${LOCATION}`, {
+    const stdout = execSync(`node ./set_endpoint.js ${projectId}`, {
       cwd,
     });
     assert.match(stdout, /Entity/);


### PR DESCRIPTION
This one is weird: the samples tests stopped working for no reason saying they don't like the `parent` field:

```
Error: 3 INVALID_ARGUMENT: Invalid request fields: parent.
```

I tried it and figured it works if we don't pass any location in the parent field. The comments in protos say this:

```
  // Format: `projects/{project-id}/locations/{location-id}`.
  //
  // If no location is specified, a region will be chosen automatically.
```

So... it all works without locations. Not sure if it's the right usage, but let's maybe merge this now to have the tests passing, and then figure out what's wrong with the API.