### PR TITLE
feat: check status of long running operation by its name

### DIFF
--- a/src/v1beta2/document_understanding_service_client.ts
+++ b/src/v1beta2/document_understanding_service_client.ts
@@ -28,7 +28,7 @@ import * as path from 'path';
 
 import * as protos from '../../protos/protos';
 import * as gapicConfig from './document_understanding_service_client_config.json';
-
+import {operationsProtos} from 'google-gax';
 const version = require('../../../package.json').version;
 
 /**
@@ -542,6 +542,42 @@ export class DocumentUnderstandingServiceClient {
     });
     this.initialize();
     return this.innerApiCalls.batchProcessDocuments(request, options, callback);
+  }
+  /**
+   * Check the status of the long running operation returned by the batchProcessDocuments() method.
+   * @param {String} name
+   *   The operation name that will be passed.
+   * @returns {Promise} - The promise which resolves to an object.
+   *   The decoded operation object has result and metadata field to get information from.
+   *
+   * @example:
+   *   const decodedOperation = await checkBatchProcessDocumentsProgress(name);
+   *   console.log(decodedOperation.result);
+   *   console.log(decodedOperation.done);
+   *   console.log(decodedOperation.metadata);
+   *
+   */
+  async checkBatchProcessDocumentsProgress(
+    name: string
+  ): Promise<
+    LROperation<
+      protos.google.cloud.documentai.v1beta2.BatchProcessDocumentsResponse,
+      protos.google.cloud.documentai.v1beta2.OperationMetadata
+    >
+  > {
+    const request = new operationsProtos.google.longrunning.GetOperationRequest(
+      {name}
+    );
+    const [operation] = await this.operationsClient.getOperation(request);
+    const decodeOperation = new gax.Operation(
+      operation,
+      this.descriptors.longrunning.batchProcessDocuments,
+      gax.createDefaultBackoffSettings()
+    );
+    return decodeOperation as LROperation<
+      protos.google.cloud.documentai.v1beta2.BatchProcessDocumentsResponse,
+      protos.google.cloud.documentai.v1beta2.OperationMetadata
+    >;
   }
 
   /**

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-document-ai.git",
-        "sha": "4cb651dfe590269cc6ad808a49b601d09447f21b"
-      }
-    },
-    {
-      "git": {
-        "name": "googleapis",
-        "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "42ee97c1b93a0e3759bbba3013da309f670a90ab",
-        "internalRef": "307114445"
+        "remote": "git@github.com:googleapis/nodejs-document-ai.git",
+        "sha": "8515d226f29f07969229575789d95a094a837d31"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "19465d3ec5e5acdb01521d8f3bddd311bcbee28d"
+        "sha": "ab883569eb0257bbf16a6d825fd018b3adde3912"
       }
     }
   ],

--- a/test/gapic_document_understanding_service_v1beta2.ts
+++ b/test/gapic_document_understanding_service_v1beta2.ts
@@ -23,7 +23,7 @@ import {SinonStub} from 'sinon';
 import {describe, it} from 'mocha';
 import * as documentunderstandingserviceModule from '../src';
 
-import {protobuf, LROperation} from 'google-gax';
+import {protobuf, LROperation, operationsProtos} from 'google-gax';
 
 function generateSampleMessage<T extends object>(instance: T) {
   const filledObject = (instance.constructor as typeof protobuf.Message).toObject(
@@ -288,9 +288,7 @@ describe('v1beta2.DocumentUnderstandingServiceClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.processDocument(request);
-      }, expectedError);
+      await assert.rejects(client.processDocument(request), expectedError);
       assert(
         (client.innerApiCalls.processDocument as SinonStub)
           .getCall(0)
@@ -418,9 +416,10 @@ describe('v1beta2.DocumentUnderstandingServiceClient', () => {
         undefined,
         expectedError
       );
-      await assert.rejects(async () => {
-        await client.batchProcessDocuments(request);
-      }, expectedError);
+      await assert.rejects(
+        client.batchProcessDocuments(request),
+        expectedError
+      );
       assert(
         (client.innerApiCalls.batchProcessDocuments as SinonStub)
           .getCall(0)
@@ -455,14 +454,57 @@ describe('v1beta2.DocumentUnderstandingServiceClient', () => {
         expectedError
       );
       const [operation] = await client.batchProcessDocuments(request);
-      await assert.rejects(async () => {
-        await operation.promise();
-      }, expectedError);
+      await assert.rejects(operation.promise(), expectedError);
       assert(
         (client.innerApiCalls.batchProcessDocuments as SinonStub)
           .getCall(0)
           .calledWith(request, expectedOptions, undefined)
       );
+    });
+
+    it('invokes checkBatchProcessDocumentsProgress without error', async () => {
+      const client = new documentunderstandingserviceModule.v1beta2.DocumentUnderstandingServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedResponse = generateSampleMessage(
+        new operationsProtos.google.longrunning.Operation()
+      );
+      expectedResponse.name = 'test';
+      expectedResponse.response = {type_url: 'url', value: Buffer.from('')};
+      expectedResponse.metadata = {type_url: 'url', value: Buffer.from('')};
+
+      client.operationsClient.getOperation = stubSimpleCall(expectedResponse);
+      const decodedOperation = await client.checkBatchProcessDocumentsProgress(
+        expectedResponse.name
+      );
+      assert.deepStrictEqual(decodedOperation.name, expectedResponse.name);
+      assert(decodedOperation.metadata);
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
+    });
+
+    it('invokes checkBatchProcessDocumentsProgress with error', async () => {
+      const client = new documentunderstandingserviceModule.v1beta2.DocumentUnderstandingServiceClient(
+        {
+          credentials: {client_email: 'bogus', private_key: 'bogus'},
+          projectId: 'bogus',
+        }
+      );
+      client.initialize();
+      const expectedError = new Error('expected');
+
+      client.operationsClient.getOperation = stubSimpleCall(
+        undefined,
+        expectedError
+      );
+      await assert.rejects(
+        client.checkBatchProcessDocumentsProgress(''),
+        expectedError
+      );
+      assert((client.operationsClient.getOperation as SinonStub).getCall(0));
     });
   });
 });


### PR DESCRIPTION
For each client method returning a long running operation, a separate method to check its status is added.

Added methods: `checkBatchProcessDocumentsProgress`.