### PR TITLE
build: replaces old link with current product doc location

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 name: ci
 jobs:

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "documentai",
   "name_pretty": "Document AI",
-  "product_documentation": "https://cloud.google.com/document-understanding/docs/",
+  "product_documentation": "https://cloud.google.com/document-ai/docs/",
   "client_documentation": "https://googleapis.dev/nodejs/documentai/latest/index.html",
   "issue_tracker": "",
   "release_level": "beta",

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Apache Version 2.0
 See [LICENSE](https://github.com/googleapis/nodejs-document-ai/blob/master/LICENSE)
 
 [client-docs]: https://googleapis.dev/nodejs/documentai/latest/index.html
-[product-docs]: https://cloud.google.com/document-understanding/docs/
+[product-docs]: https://cloud.google.com/document-ai/docs/
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Document AI client for Node.js
 
 
 A comprehensive list of changes in each version may be found in
-[the CHANGELOG](https://github.com/googleapis/nodejs-document-ai/blob/master/CHANGELOG.md).
+[the CHANGELOG](https://github.com/googleapis/nodejs-document-ai/blob/main/CHANGELOG.md).
 
 * [Document AI Node.js Client API Reference][client-docs]
 * [Document AI Documentation][product-docs]
@@ -132,19 +132,19 @@ async function quickstart() {
 
 ## Samples
 
-Samples are in the [`samples/`](https://github.com/googleapis/nodejs-document-ai/tree/master/samples) directory. Each sample's `README.md` has instructions for running its sample.
+Samples are in the [`samples/`](https://github.com/googleapis/nodejs-document-ai/tree/main/samples) directory. Each sample's `README.md` has instructions for running its sample.
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
-| Batch-parse-form.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/batch-parse-form.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-parse-form.v1beta2.js,samples/README.md) |
-| Batch-parse-table.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/batch-parse-table.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-parse-table.v1beta2.js,samples/README.md) |
-| Batch-process-document | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/batch-process-document.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-process-document.js,samples/README.md) |
-| Parse-form.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/parse-form.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-form.v1beta2.js,samples/README.md) |
-| Parse-table.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/parse-table.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-table.v1beta2.js,samples/README.md) |
-| Parse-with-model.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/parse-with-model.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-with-model.v1beta2.js,samples/README.md) |
-| Process-document | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/process-document.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/process-document.js,samples/README.md) |
-| Quickstart | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/quickstart.js,samples/README.md) |
-| Set-endpoint.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/set-endpoint.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/set-endpoint.v1beta2.js,samples/README.md) |
+| Batch-parse-form.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/batch-parse-form.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-parse-form.v1beta2.js,samples/README.md) |
+| Batch-parse-table.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/batch-parse-table.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-parse-table.v1beta2.js,samples/README.md) |
+| Batch-process-document | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/batch-process-document.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-process-document.js,samples/README.md) |
+| Parse-form.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/parse-form.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-form.v1beta2.js,samples/README.md) |
+| Parse-table.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/parse-table.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-table.v1beta2.js,samples/README.md) |
+| Parse-with-model.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/parse-with-model.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-with-model.v1beta2.js,samples/README.md) |
+| Process-document | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/process-document.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/process-document.js,samples/README.md) |
+| Quickstart | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/quickstart.js,samples/README.md) |
+| Set-endpoint.v1beta2 | [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/set-endpoint.v1beta2.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/set-endpoint.v1beta2.js,samples/README.md) |
 
 
 
@@ -192,7 +192,7 @@ More Information: [Google Cloud Platform Launch Stages][launch_stages]
 
 ## Contributing
 
-Contributions welcome! See the [Contributing Guide](https://github.com/googleapis/nodejs-document-ai/blob/master/CONTRIBUTING.md).
+Contributions welcome! See the [Contributing Guide](https://github.com/googleapis/nodejs-document-ai/blob/main/CONTRIBUTING.md).
 
 Please note that this `README.md`, the `samples/README.md`,
 and a variety of configuration files in this repository (including `.nycrc` and `tsconfig.json`)
@@ -204,7 +204,7 @@ to its template in this
 
 Apache Version 2.0
 
-See [LICENSE](https://github.com/googleapis/nodejs-document-ai/blob/master/LICENSE)
+See [LICENSE](https://github.com/googleapis/nodejs-document-ai/blob/main/LICENSE)
 
 [client-docs]: https://googleapis.dev/nodejs/documentai/latest/index.html
 [product-docs]: https://cloud.google.com/document-ai/docs/

--- a/samples/README.md
+++ b/samples/README.md
@@ -191,4 +191,4 @@ __Usage:__
 
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/README.md
-[product-docs]: https://cloud.google.com/document-understanding/docs/
+[product-docs]: https://cloud.google.com/document-ai/docs/

--- a/samples/README.md
+++ b/samples/README.md
@@ -39,7 +39,7 @@ Before running the samples, make sure you've followed the steps outlined in
 
 ### Batch-parse-form.v1beta2
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/batch-parse-form.v1beta2.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/batch-parse-form.v1beta2.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-parse-form.v1beta2.js,samples/README.md)
 
@@ -56,7 +56,7 @@ __Usage:__
 
 ### Batch-parse-table.v1beta2
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/batch-parse-table.v1beta2.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/batch-parse-table.v1beta2.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-parse-table.v1beta2.js,samples/README.md)
 
@@ -73,7 +73,7 @@ __Usage:__
 
 ### Batch-process-document
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/batch-process-document.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/batch-process-document.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/batch-process-document.js,samples/README.md)
 
@@ -90,7 +90,7 @@ __Usage:__
 
 ### Parse-form.v1beta2
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/parse-form.v1beta2.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/parse-form.v1beta2.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-form.v1beta2.js,samples/README.md)
 
@@ -107,7 +107,7 @@ __Usage:__
 
 ### Parse-table.v1beta2
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/parse-table.v1beta2.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/parse-table.v1beta2.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-table.v1beta2.js,samples/README.md)
 
@@ -124,7 +124,7 @@ __Usage:__
 
 ### Parse-with-model.v1beta2
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/parse-with-model.v1beta2.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/parse-with-model.v1beta2.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/parse-with-model.v1beta2.js,samples/README.md)
 
@@ -141,7 +141,7 @@ __Usage:__
 
 ### Process-document
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/process-document.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/process-document.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/process-document.js,samples/README.md)
 
@@ -158,7 +158,7 @@ __Usage:__
 
 ### Quickstart
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/quickstart.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/quickstart.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/quickstart.js,samples/README.md)
 
@@ -175,7 +175,7 @@ __Usage:__
 
 ### Set-endpoint.v1beta2
 
-View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/master/samples/set-endpoint.v1beta2.js).
+View the [source code](https://github.com/googleapis/nodejs-document-ai/blob/main/samples/set-endpoint.v1beta2.js).
 
 [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-document-ai&page=editor&open_in_editor=samples/set-endpoint.v1beta2.js,samples/README.md)
 


### PR DESCRIPTION
Fixes #255 🦕
